### PR TITLE
changes suggested by David, see description of pull request for more details

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -31,6 +31,7 @@ class Game {
         } else if (isGameOver && keyCode === ESCAPE) {
             isGameOver = false;
             isStartMenu = true;
+            this.gameManager = new GameManager();
         }
     }
 
@@ -57,7 +58,6 @@ class Game {
 
         if (isGameOver) {
             this.gameOverScene.draw();
-            game = new Game; // not done
         } else if (isRunning) {
             this.gameManager.draw();
         } else if (isStartMenu) {

--- a/src/gamemanager.ts
+++ b/src/gamemanager.ts
@@ -5,18 +5,24 @@ interface GameWindow {
     x: number;
     y: number;
 }
+interface ObstacleData {
+    image: p5.Image[];
+    width: number;
+    height: number;
+    speed: number;
+}
+
 
 class GameManager {
     public rocket: Rocket;
-    private obstacleData: object[]
+    private obstacleData: ObstacleData[]
     public obstacles: Obstacle[]
     private timeCounter: number;
     private speedDuration: number;
     public scoreBoard: ScoreBoard;
-    static rocket: Rocket;
 
     constructor() {
-        this.rocket = new Rocket(images.rocket, 10, (height - 115) / 2, 115, 63, 5)
+        this.rocket = new Rocket(10, (height - 115) / 2, 115, 63, 5)
         this.scoreBoard = new ScoreBoard(this);
 
         this.timeCounter = 0;
@@ -59,8 +65,7 @@ class GameManager {
     }
 
     private createObstacle() {
-        let obstacleData: any = {}
-        obstacleData = random(this.obstacleData);
+        const obstacleData = random(this.obstacleData);
         let yPos = random(-10, height - obstacleData.height + 10);
         let xPos = width;
         this.obstacles.push(new Obstacle(obstacleData.image, xPos, yPos, obstacleData.width, obstacleData.height, obstacleData.speed, random(200, 160)));

--- a/src/movingobject.ts
+++ b/src/movingobject.ts
@@ -1,3 +1,10 @@
+interface HitBox {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+}
+
 class MovingObject {
     public x: number;
     public y: number;
@@ -7,14 +14,16 @@ class MovingObject {
     protected angle: number;
     protected animationTimeCounter: number;
     protected images: p5.Image[] = [];
+    protected hitBox: HitBox;
 
-    constructor(images: p5.Image[], x: number, y: number, width: number, height: number, speed: number, angle?: number) {
+    constructor(images: p5.Image[], x: number, y: number, width: number, height: number, speed: number, hitBox: HitBox, angle?: number) {
         this.images = images;
         this.x = x;
         this.y = y;
         this.width = width;
         this.height = height;
         this.speed = speed;
+        this.hitBox = hitBox;
         this.angle = angle ?? 0;
         this.animationTimeCounter = 0;
     }
@@ -28,6 +37,28 @@ class MovingObject {
     }
 
     public draw() {
+        let i;
+        if (this.animationTimeCounter < 500) {
+            i = 0;
+        } else {
+            i = 1;
+        }
+        image(this.images[i], this.x, this.y, this.width, this.height)
+        if (this.animationTimeCounter >= 1000) {
+            this.animationTimeCounter = 0;
+        }
+        
+        this.drawHitBox();
+    }
+
+    private drawHitBox() {
+        push();
+        stroke('red');
+        noFill();
+        const x = this.x + this.hitBox.x;
+        const y = this.y + this.hitBox.y;
+        rect(x, y, this.hitBox.width, this.hitBox.height)
+        pop();
     }
 
 }

--- a/src/obstacle.ts
+++ b/src/obstacle.ts
@@ -1,23 +1,22 @@
 
 class Obstacle extends MovingObject {
-    public isBehindRocket: Boolean = false;
+    public isBehindRocket: Boolean;
 
-    public draw() {
-        this.update();
+    constructor(images: p5.Image[], x: number, y: number, width: number, height: number, speed: number, angle?: number) {
+        const hitBox: HitBox = {
+            x: 0,
+            y: 0,
+            width: width,
+            height: height
+        };
+        super(images, x, y, width, height, speed, hitBox, angle);
+        
+        this.isBehindRocket = false;
+    }
+
+    public update() {
+        super.update();
         this.fadeInObstacle();
-
-        let i;
-        if (this.animationTimeCounter < 500) {
-            i = 0;
-        } else {
-            i = 1;
-        }
-
-        image(this.images[i], this.x, this.y, this.width, this.height);
-
-        if (this.animationTimeCounter >= 1000) {
-            this.animationTimeCounter = 0;
-        }
     }
 
     protected fadeInObstacle() {

--- a/src/rocket.ts
+++ b/src/rocket.ts
@@ -1,5 +1,16 @@
 class Rocket extends MovingObject {
 
+    constructor(x: number, y: number, width: number, height: number, speed: number, angle?: number) {
+        const hitBox: HitBox = {
+            x: width * .15,
+            y: height * .25,
+            width: width * .8,
+            height: height * .5
+        }
+        
+        super(images.rocket, x, y, width, height, speed, hitBox, angle);
+    }
+
     protected moveUp() {
         this.y -= this.speed;
         if (this.y < 0) {
@@ -21,20 +32,10 @@ class Rocket extends MovingObject {
         }
     }
 
-    public draw() {
-        this.update();
+    public update() {
+        super.update();
         this.moveToStart();
-
-        let i;
-        if (this.animationTimeCounter < 500) {
-            i = 0;
-        } else {
-            i = 1;
-        } image(this.images[i], this.x, this.y, this.width, this.height)
-        if (this.animationTimeCounter >= 1000) {
-            this.animationTimeCounter = 0;
-        }
-
+        
         if (keyIsDown(UP_ARROW)) {
             this.moveUp();
         } else if (keyIsDown(DOWN_ARROW)) {

--- a/src/scoreboard.ts
+++ b/src/scoreboard.ts
@@ -1,10 +1,10 @@
-let score: number;
-score = 0;
 class ScoreBoard {
+    private score: number;
     gameManager: GameManager;
 
     constructor(gameManager: GameManager) {
         this.gameManager = gameManager;
+        this.score = 0;
         textFont(font);
         textSize(20);
         textAlign(RIGHT);
@@ -21,7 +21,7 @@ class ScoreBoard {
 
     private showCurrentScore() {
         fill(255);
-        text('SCORE ' + score, 800, 25);
+        text('SCORE ' + this.score, 800, 25);
     }
 
     private showBestScore() {
@@ -37,6 +37,6 @@ class ScoreBoard {
     }
 
     public addScoreForPassingObstacle() {
-        score += 10;
+        this.score += 10;
     }
 }


### PR DESCRIPTION
Problems we had: 
1. the obstacle and rocket pics are rectangles so the size and x/y were not exact or accurate when checking if there is a collision 
2. scoreboard was not reset when restarted game 

Solutions suggested by David:
1. create hitboxes for all moving objects for collision checking instead of the image's original size
2. remove all global variables (score and the booleans for game status) 